### PR TITLE
Integrate sidebar component

### DIFF
--- a/public/components/CountrySidebar.tsx
+++ b/public/components/CountrySidebar.tsx
@@ -1,0 +1,143 @@
+import { useState } from 'react';
+import { ChevronDown, Globe, Banknote, Landmark, Shield, Users, Globe2, Cpu, Palette } from 'lucide-react';
+
+interface CategoryGroupProps {
+  icon: React.ReactNode;
+  title: string;
+  items: string[];
+}
+
+function CategoryGroup({ icon, title, items }: CategoryGroupProps) {
+  const [open, setOpen] = useState(false);
+  return (
+    <div className="border-b border-slate-800">
+      <button
+        className="flex w-full items-center gap-2 p-2 hover:bg-slate-800"
+        onClick={() => setOpen(!open)}
+      >
+        {icon}
+        <span>{title}</span>
+        <ChevronDown className={`ml-auto h-4 w-4 transition-transform ${open ? 'rotate-180' : ''}`} />
+      </button>
+      {open && (
+        <ul className="pl-6 pb-2 text-sm text-slate-300">
+          {items.map((item) => (
+            <li key={item} className="py-0.5 hover:text-slate-100">
+              <a href={`#${item.toLowerCase().replace(/\s+/g, '-')}`}>{item}</a>
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}
+
+export default function CountrySidebar() {
+  return (
+    <div className="fixed right-0 top-0 z-20 h-full w-64 bg-slate-900/95 text-slate-200 overflow-y-auto shadow-lg">
+      <div className="p-4 border-b border-slate-800">
+        <input
+          placeholder="Search country data..."
+          className="w-full rounded bg-slate-900 border border-slate-700 p-2 text-slate-200 placeholder-slate-400"
+        />
+      </div>
+      <div className="p-2 space-y-2">
+        <CategoryGroup
+          icon={<Globe className="text-blue-400" />}
+          title="General Information"
+          items={[
+            'Official Name',
+            'Flag',
+            'Surface Area',
+            'Languages',
+            'Currency',
+            'ISO Code',
+            'Continent',
+            'Capital City',
+            'Population',
+            'Government Type',
+          ]}
+        />
+        <CategoryGroup
+          icon={<Banknote className="text-green-400" />}
+          title="Economy"
+          items={[
+            'GDP (Gross Domestic Product)',
+            'GDP per Capita',
+            'Inflation Rate',
+            'GINI Index',
+            'GDP Sector Breakdown',
+            'Exports & Imports',
+            'Main Trade Partners',
+            'External Debt',
+            'Unemployment Rate',
+          ]}
+        />
+        <CategoryGroup
+          icon={<Landmark className="text-purple-400" />}
+          title="Politics"
+          items={['Political Parties', 'Political System', 'Head of State / Government', 'Political Stability']}
+        />
+        <CategoryGroup
+          icon={<Shield className="text-red-400" />}
+          title="Defence"
+          items={[
+            'Military Budget',
+            'Armed Forces Size',
+            'Active Conflicts',
+            'Peace Operations',
+            'Main Military Adversaries',
+          ]}
+        />
+        <CategoryGroup
+          icon={<Users className="text-yellow-400" />}
+          title="Social"
+          items={[
+            'Life Expectancy',
+            'Literacy Rate',
+            'Poverty Indicators',
+            'Health & Education Access',
+            'Human Development Index (HDI)',
+            'Demographics',
+            'Birth / Death Rates',
+            'Urban / Rural Population (%)',
+            'Population Density',
+          ]}
+        />
+        <CategoryGroup
+          icon={<Globe2 className="text-cyan-400" />}
+          title="International"
+          items={[
+            'International Organizations Membership',
+            'Treaties',
+            'Regional Cooperation',
+            'Official Development Assistance (ODA)',
+            'Top Recipients',
+            'Rival Countries',
+            'Key Allies',
+          ]}
+        />
+        <CategoryGroup
+          icon={<Cpu className="text-indigo-400" />}
+          title="Technology & National Assets"
+          items={[
+            'R&D Index',
+            'Tech Exports',
+            'Top National Companies',
+            'State-Owned Enterprises (SOEs)',
+            'Strategic Holdings',
+            'Sovereign Wealth Funds',
+            'Strategic Industries & Specializations',
+            'Industrial Policy',
+            'Critical Minerals & Share of Global Supply',
+          ]}
+        />
+        <CategoryGroup
+          icon={<Palette className="text-pink-400" />}
+          title="Culture"
+          items={['Religions', 'UNESCO World Heritage Sites', 'Soft Power Metrics']}
+        />
+      </div>
+    </div>
+  );
+}

--- a/public/components/WorldMap.tsx
+++ b/public/components/WorldMap.tsx
@@ -35,8 +35,9 @@ export default function WorldMap() {
 
     // Buscador de países en inglés
     const geocoder = new MapboxGeocoder({
-      accessToken: mapboxgl.accessToken,
-      mapboxgl,
+      accessToken: mapboxgl.accessToken as string,
+      // Type cast mapboxgl to any to avoid TS mismatch with the geocoder library
+      mapboxgl: mapboxgl as any,
       types: 'country',
       language: 'en',
       placeholder: 'Search country'

--- a/public/package-lock.json
+++ b/public/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@mapbox/mapbox-gl-geocoder": "^5.0.3",
         "framer-motion": "^12.16.0",
+        "lucide-react": "^0.454.0",
         "mapbox-gl": "^3.12.0",
         "react": "^19.1.0",
         "react-dom": "^19.1.0"
@@ -17,6 +18,7 @@
       "devDependencies": {
         "@eslint/js": "^9.25.0",
         "@tailwindcss/postcss": "^4.1.8",
+        "@types/mapbox__mapbox-gl-geocoder": "^5.0.0",
         "@types/react": "^19.1.2",
         "@types/react-dom": "^19.1.2",
         "@vitejs/plugin-react": "^4.4.1",
@@ -1893,6 +1895,17 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/mapbox__mapbox-gl-geocoder": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@types/mapbox__mapbox-gl-geocoder/-/mapbox__mapbox-gl-geocoder-5.0.0.tgz",
+      "integrity": "sha512-eGBWdFiP2QgmwndPyhwK6eBeOfyB8vRscp2C6Acqasx5dH8FvTo/VgXWCrCKFR3zkWek/H4w4/CwmBFOs7OLBA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/geojson": "*",
+        "@types/mapbox-gl": "*"
+      }
+    },
     "node_modules/@types/mapbox__point-geometry": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/@types/mapbox__point-geometry/-/mapbox__point-geometry-0.1.4.tgz",
@@ -1908,6 +1921,16 @@
         "@types/geojson": "*",
         "@types/mapbox__point-geometry": "*",
         "@types/pbf": "*"
+      }
+    },
+    "node_modules/@types/mapbox-gl": {
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/@types/mapbox-gl/-/mapbox-gl-3.4.1.tgz",
+      "integrity": "sha512-NsGKKtgW93B+UaLPti6B7NwlxYlES5DpV5Gzj9F75rK5ALKsqSk15CiEHbOnTr09RGbr6ZYiCdI+59NNNcAImg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/geojson": "*"
       }
     },
     "node_modules/@types/minimist": {
@@ -4174,6 +4197,15 @@
       "license": "ISC",
       "dependencies": {
         "yallist": "^3.0.2"
+      }
+    },
+    "node_modules/lucide-react": {
+      "version": "0.454.0",
+      "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-0.454.0.tgz",
+      "integrity": "sha512-hw7zMDwykCLnEzgncEEjHeA6+45aeEzRYuKHuyRSOPkhko+J3ySGjGIzu+mmMfDFG1vazHepMaYFYHbTFAZAAQ==",
+      "license": "ISC",
+      "peerDependencies": {
+        "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0-rc"
       }
     },
     "node_modules/magic-string": {

--- a/public/package.json
+++ b/public/package.json
@@ -12,6 +12,7 @@
   "dependencies": {
     "@mapbox/mapbox-gl-geocoder": "^5.0.3",
     "framer-motion": "^12.16.0",
+    "lucide-react": "^0.454.0",
     "mapbox-gl": "^3.12.0",
     "react": "^19.1.0",
     "react-dom": "^19.1.0"
@@ -19,6 +20,7 @@
   "devDependencies": {
     "@eslint/js": "^9.25.0",
     "@tailwindcss/postcss": "^4.1.8",
+    "@types/mapbox__mapbox-gl-geocoder": "^5.0.0",
     "@types/react": "^19.1.2",
     "@types/react-dom": "^19.1.2",
     "@vitejs/plugin-react": "^4.4.1",

--- a/public/src/App.tsx
+++ b/public/src/App.tsx
@@ -1,6 +1,7 @@
 import { useState, useEffect } from 'react';
 import WorldMap from '../components/WorldMap';
 import CountryCard from '../components/CountryCard';
+import CountrySidebar from '../components/CountrySidebar';
 import './index.css';
 
 interface Country {
@@ -31,6 +32,7 @@ function App() {
   return (
     <div className="relative w-full h-full overflow-hidden">
       <WorldMap />
+      <CountrySidebar />
       {/* Pantalla de carga opcional */}
       {isLoading && (
         <div className="absolute inset-0 bg-gray-900 bg-opacity-50 flex items-center justify-center z-50">


### PR DESCRIPTION
## Summary
- add lucide-react and mapbox geocoder types
- implement `CountrySidebar` component with collapsible groups
- hook sidebar into `App.tsx`
- tweak mapbox geocoder types

## Testing
- `npm run build`
- `npm test` *(fails: Missing script)*
- `cd public && npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6841cfd95c1c832fa21d9cdeaa5c1216