### PR TITLE
Fix ui and country leader display bug

### DIFF
--- a/frontend/hooks/usePoliticsData.ts
+++ b/frontend/hooks/usePoliticsData.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import { politicsService, TPoliticsData } from '../services/politics-service';
 
 export interface UsePoliticsDataReturn {
@@ -12,19 +12,29 @@ export function usePoliticsData(countryName: string | null, iso3: string | null)
   const [data, setData] = useState<TPoliticsData | null>(null);
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const requestIdRef = useRef(0);
 
   const fetchData = useCallback(async (name: string, code3: string) => {
+    // Increment request id and capture local id for this run
+    const currentRequestId = ++requestIdRef.current;
     setIsLoading(true);
     setError(null);
+    // Clear previous data immediately to avoid showing stale entries
+    setData(null);
     try {
       const result = await politicsService.getPoliticsData(name, code3);
+      // Ignore if a newer request has been started
+      if (currentRequestId !== requestIdRef.current) return;
       setData(result);
     } catch (err) {
+      if (currentRequestId !== requestIdRef.current) return;
       const message = err instanceof Error ? err.message : 'Failed to load politics data';
       setError(message);
       setData(null);
     } finally {
-      setIsLoading(false);
+      if (currentRequestId === requestIdRef.current) {
+        setIsLoading(false);
+      }
     }
   }, []);
 
@@ -36,6 +46,8 @@ export function usePoliticsData(countryName: string | null, iso3: string | null)
     if (countryName && iso3) {
       fetchData(countryName, iso3);
     } else {
+      // Invalidate any in-flight requests
+      requestIdRef.current++;
       setData(null);
       setError(null);
       setIsLoading(false);


### PR DESCRIPTION
Fix race condition in `usePoliticsData` to prevent stale or merged politics data when switching countries.

Previously, rapidly switching countries could lead to a bug where leaders from the previously selected country would still be displayed, sometimes mixed with the new country's leaders, due to out-of-order API responses or delayed state updates.

---
<a href="https://cursor.com/background-agent?bcId=bc-8756bd37-119f-4f0f-bc5e-ffb0b1e584bb">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-8756bd37-119f-4f0f-bc5e-ffb0b1e584bb">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

