### PR TITLE
Ingest and display wikidata events on map

### DIFF
--- a/frontend/components/LeftSidebar.tsx
+++ b/frontend/components/LeftSidebar.tsx
@@ -7,6 +7,7 @@ interface LeftSidebarProps {
   onClose: () => void;
   onCenterMap?: (coordinates: { lat: number; lng: number }) => void;
   onOpenConflictTracker?: () => void;
+  onOpenWorldMap?: () => void;
 }
 
 interface MenuItem {
@@ -16,7 +17,7 @@ interface MenuItem {
   onClick?: () => void;
 }
 
-export default function LeftSidebar({ isOpen, onOpenConflictTracker }: LeftSidebarProps) {
+export default function LeftSidebar({ isOpen, onOpenConflictTracker, onOpenWorldMap }: LeftSidebarProps) {
   const [activeItem, setActiveItem] = useState<string>('home');
 
   const menuItems: MenuItem[] = useMemo(() => [
@@ -68,6 +69,11 @@ export default function LeftSidebar({ isOpen, onOpenConflictTracker }: LeftSideb
     // Handle Conflict Tracker specifically
     if (item.label === 'Conflict Tracker' && onOpenConflictTracker) {
       onOpenConflictTracker();
+      return;
+    }
+    // Handle World Map specifically
+    if (item.label === 'World Map' && onOpenWorldMap) {
+      onOpenWorldMap();
       return;
     }
     

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -92,6 +92,19 @@ function App() {
     setSelectedConflictId(null);
   }, [toggleSidebar]);
 
+  // Open the World Map section from the left sidebar
+  const handleOpenWorldMap = useCallback(() => {
+    // Close detail sidebars and reset selections
+    toggleSidebar('country', false);
+    toggleSidebar('conflict', false);
+    setSelectedCountry(null);
+    setSelectedConflictId(null);
+    // Reset map view if exposed
+    if ((window as WindowWithResetMapView).resetMapView) {
+      (window as WindowWithResetMapView).resetMapView();
+    }
+  }, [toggleSidebar]);
+
   // Removed: unused handleBackToLeftSidebar
 
   const handleCenterMapOnConflict = (coordinates: { lat: number; lng: number }) => {
@@ -145,6 +158,7 @@ function App() {
         isOpen={sidebars.menu}
         onClose={handleCloseLeftSidebar}
         onOpenConflictTracker={handleOpenConflictTracker}
+        onOpenWorldMap={handleOpenWorldMap}
       />
       
       {/* Left sidebar overlay */}


### PR DESCRIPTION
Add a "World Map" entry to the left sidebar and its handler to focus the map view.

---
<a href="https://cursor.com/background-agent?bcId=bc-ad568d7d-96e0-4979-bf46-97743e3bf2c7">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-ad568d7d-96e0-4979-bf46-97743e3bf2c7">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

